### PR TITLE
ci(INFRA-18): reusable workflows moved to voikyrioh/workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   release:
-    uses: voikyrioh/infra-as-code/.github/workflows/ci-release.yml@main
+    uses: voikyrioh/workflows/.github/workflows/ci-release.yml@main
     with:
       app_name: webgpu-cube
       bump_type: ${{ inputs.bump_type }}


### PR DESCRIPTION
Le repo infra-as-code passe en prive (INFRA-18) : les workflows reutilisables vivent desormais dans le repo public voikyrioh/workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)